### PR TITLE
Merge changes from user ps251 config

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2023 Ivan Danov
+Copyright (c) 2024 Frederick Morlock
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/org-roam-logseq.el
+++ b/org-roam-logseq.el
@@ -41,15 +41,20 @@
 (require 'cl-lib)
 (require 'org-roam)
 
+;; Your logseq directory should be inside your org-roam directory,
+;; put the directory you use here
+;; e.g. (defvar org-roam-logseq-folder (f-expand (f-join org-roam-directory "zettel")))
+(defcustom org-roam-logseq-logseq-folder (f-expand org-roam-directory) "root of the logseq directory")
+
 ;; You probably don't need to change these values
-(defcustom org-roam-logseq-logseq-journals (f-expand (f-join org-roam-directory "journals")) "logseq journal directory")
+(defcustom org-roam-logseq-logseq-journals (f-expand (f-join org-roam-logseq-logseq-folder "journals")) "logseq journal directory")
 
 ;; default: exclude all files in the logseq/bak/ folder
-(defcustom org-roam-logseq-logseq-exclude-pattern (string-join (list "^" (file-truename org-roam-directory) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
+(defcustom org-roam-logseq-logseq-exclude-pattern (string-join (list "^" (file-truename org-roam-logseq-logseq-folder) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
 (defcustom org-roam-logseq/ignore-journal-files t "When non-nil, journal files will be ignored")
 
 
-(defcustom org-roam-logseq/logseq-id-title-mod-path (f-expand (f-join org-roam-directory "pages/")) "paths where id and title additions are allowed")
+(defcustom org-roam-logseq/logseq-id-title-mod-path (f-expand (f-join org-roam-logseq-logseq-folder "pages/")) "paths where id and title additions are allowed")
 
 (defcustom org-roam-logseq/ignore-file-links t "When non-nil, file-links will not be converted, only fuzzy links")
 
@@ -61,75 +66,75 @@
   ;; do nothing at all when file is excluded by exclude pattern
   (if (string-match-p org-roam-logseq-logseq-exclude-pattern (file-truename file))
       (cons nil nil)
-   (if (or (and org-roam-logseq/ignore-journal-files (org-roam-logseq-logseq-journal-p file) ) (not (string-match-p (concat "^" org-roam-logseq/logseq-id-title-mod-path) file)))
-      ;; do not add id and title for journal files if org-roam-logseq/ignore-journal-files is non-nil. Also if file doesn't match org-roam-logseq/logseq-id-title-mod-path
-      (if-let ( (buf (get-file-buffer file)) )
-          (cons nil buf)
-        (cons t (find-file-noselect file))
-        )
-    (let* ((buf (get-file-buffer file))
-           (was-modified (buffer-modified-p buf))
-           (new-buf nil)
-           has-data
-           org
-           changed
-           sec-end)
-      (when (not buf)
-        (setq buf (find-file-noselect file))
-        (setq new-buf t))
-      (set-buffer buf)
-      (setq org (org-element-parse-buffer))
-      (setq has-data (cddr org))
-      (goto-char 1)
-      (when (not (and (eq 'section (org-element-type (nth 2 org))) (org-roam-id-at-point)))
-        ;; this file has no file id
-        (setq changed t)
-        (when (eq 'headline (org-element-type (nth 2 org)))
-          ;; if there's no section before the first headline, add one
-          (insert "\n")
-          (goto-char 1))
-        (org-id-get-create)
-        (setq org (org-element-parse-buffer)))
-      (when (nth 3 org)
-        (when (not (org-collect-keywords ["title"]))
-          ;; no title -- ensure there's a blank line at the section end
+    (if (or (and org-roam-logseq/ignore-journal-files (org-roam-logseq-logseq-journal-p file) ) (not (string-match-p (concat "^" org-roam-logseq/logseq-id-title-mod-path) file)))
+        ;; do not add id and title for journal files if org-roam-logseq/ignore-journal-files is non-nil. Also if file doesn't match org-roam-logseq/logseq-id-title-mod-path
+        (if-let ( (buf (get-file-buffer file)) )
+            (cons nil buf)
+          (cons t (find-file-noselect file))
+          )
+      (let* ((buf (get-file-buffer file))
+             (was-modified (buffer-modified-p buf))
+             (new-buf nil)
+             has-data
+             org
+             changed
+             sec-end)
+        (when (not buf)
+          (setq buf (find-file-noselect file))
+          (setq new-buf t))
+        (set-buffer buf)
+        (setq org (org-element-parse-buffer))
+        (setq has-data (cddr org))
+        (goto-char 1)
+        (when (not (and (eq 'section (org-element-type (nth 2 org))) (org-roam-id-at-point)))
+          ;; this file has no file id
           (setq changed t)
-          (setq sec-end (org-element-property :end (nth 2 org)))
-          (goto-char (1- sec-end))
-          (when (and (not (equal "\n\n" (buffer-substring-no-properties (- sec-end 2) sec-end))))
+          (when (eq 'headline (org-element-type (nth 2 org)))
+            ;; if there's no section before the first headline, add one
             (insert "\n")
-            (goto-char (1- (point)))
-            (setq org (org-element-parse-buffer)))
-          ;; in case of no title, make the title the same as the filename
-          (let ((title (file-name-sans-extension (file-name-nondirectory file))))
-            (insert (format "#+title: %s" title)))
-          ))
-      ;; ensure org-roam knows about the new id and/or title
-      (when changed (save-buffer))
-      (cons new-buf buf))) ))
+            (goto-char 1))
+          (org-id-get-create)
+          (setq org (org-element-parse-buffer)))
+        (when (nth 3 org)
+          (when (not (org-collect-keywords ["title"]))
+            ;; no title -- ensure there's a blank line at the section end
+            (setq changed t)
+            (setq sec-end (org-element-property :end (nth 2 org)))
+            (goto-char (1- sec-end))
+            (when (and (not (equal "\n\n" (buffer-substring-no-properties (- sec-end 2) sec-end))))
+              (insert "\n")
+              (goto-char (1- (point)))
+              (setq org (org-element-parse-buffer)))
+            ;; in case of no title, make the title the same as the filename
+            (let ((title (file-name-sans-extension (file-name-nondirectory file))))
+              (insert (format "#+title: %s" title)))
+            ))
+        ;; ensure org-roam knows about the new id and/or title
+        (when changed (save-buffer))
+        (cons new-buf buf))) ))
 
 (defun org-roam-logseq-convert-logseq-file (buf)
   "convert fuzzy and file:../pages logseq links in the file to id links"
   (if (string-match-p org-roam-logseq-logseq-exclude-pattern (file-truename (buffer-file-name buf)))
       ;; do nothing at all if file is in exclude pattern
       nil
-   (save-excursion
-    (let* (changed
-           link)
-      (set-buffer buf)
-      (goto-char 1)
-      (while (search-forward "[[" nil t)
-        (setq link (org-element-context))
-        (setq newlink (org-roam-logseq-reformat-link link))
-        (when newlink
-          (setq changed t)
-          (goto-char (org-element-property :begin link))
-          (delete-region (org-element-property :begin link) (org-element-property :end link))
-          ;; note, this format string is reall =[[%s][%s]]= but =%= is a markup char so one's hidden
-          (insert newlink)
-          (message "Convering logseq file %s link from %s to %s" (buffer-file-name buf) (org-element-property :raw-link link) newlink)))
-      ;; ensure org-roam knows about the changed links
-      (when changed (save-buffer)))) ))
+    (save-excursion
+      (let* (changed
+             link)
+        (set-buffer buf)
+        (goto-char 1)
+        (while (search-forward "[[" nil t)
+          (setq link (org-element-context))
+          (setq newlink (org-roam-logseq-reformat-link link))
+          (when newlink
+            (setq changed t)
+            (goto-char (org-element-property :begin link))
+            (delete-region (org-element-property :begin link) (org-element-property :end link))
+            ;; note, this format string is reall =[[%s][%s]]= but =%= is a markup char so one's hidden
+            (insert newlink)
+            (message "Convering logseq file %s link from %s to %s" (buffer-file-name buf) (org-element-property :raw-link link) newlink)))
+        ;; ensure org-roam knows about the changed links
+        (when changed (save-buffer)))) ))
 
 (defun org-roam-logseq-reformat-link (link)
   (let (filename
@@ -191,18 +196,18 @@
 (defun org-roam-logseq-modified-logseq-files ()
   (emacsql-with-transaction (org-roam-db)
     (seq-filter 'org-roam-logseq-roam-file-modified-p
-                (org-roam--list-files org-roam-directory))))
+                (org-roam--list-files org-roam-logseq-logseq-folder))))
 
 (defun org-roam-logseq-check-logseq ()
   (interactive)
-  (setq files (org-roam--list-files org-roam-directory))
+  (setq files (org-roam--list-files org-roam-logseq-logseq-folder))
   (message "org-roam-logseq-check-logseq is processing %d" (length files))
   (org-roam-logseq-patch files)
   )
 
 (defun org-roam-logseq-check-logseq-unsynced ()
   (interactive)
-  (setq files (org-roam--list-files org-roam-directory))
+  (setq files (org-roam--list-files org-roam-logseq-logseq-folder))
   (setq files-in-db (apply #'append (org-roam-db-query [:select file :from files])))
   (setq unsynced-files (cl-set-difference files files-in-db :test #'file-equal-p))
   (message "org-roam-logseq-check-logseq-unsynced is processing %d" (length unsynced-files))

--- a/org-roam-logseq.el
+++ b/org-roam-logseq.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/idanov/org-roam-logseq.el/
 ;; Keywords: org-mode, roam, logseq
 ;; Version: 0.1.0
-;; Package-Requires: ((org-roam "2.2.2") (cl-lib))
+;; Package-Requires: ((emacs "29") (org-roam "2.2.2") (cl-lib "1.0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -42,29 +42,40 @@
 (require 'cl-lib)
 (require 'org-roam)
 
+(defgroup org-roam-logseq nil
+  "Org-roam Logseq converter"
+  :group 'org-roam
+  :prefix "org-roam-logseq-"
+  :link '(url-link :tag "Github" "https://github.com/FrederickGeek8/org-roam-logseq.el"))
+
 ;; Your logseq directory should be inside your org-roam directory,
 ;; put the directory you use here
 ;; e.g. (defvar org-roam-logseq-folder (f-expand (f-join org-roam-directory "zettel")))
-(defcustom org-roam-logseq/logseq-folder (f-expand org-roam-directory) "root of the logseq directory")
+(defcustom org-roam-logseq/logseq-folder (f-expand org-roam-directory) "Root of the logseq directory." :type 'directory :group 'org-roam-logseq)
 
 ;; You probably don't need to change these values
-(defcustom org-roam-logseq/logseq-journals (f-expand (f-join org-roam-logseq/logseq-folder "journals")) "logseq journal directory")
-(defcustom org-roam-logseq/logseq-pages (f-expand (f-join org-roam-logseq/logseq-folder "pages")) "logseq pages directory")
+(defcustom org-roam-logseq/logseq-journals (f-expand (f-join org-roam-logseq/logseq-folder "journals")) "Logseq journal directory." :type 'directory :group 'org-roam-logseq)
+(defcustom org-roam-logseq/logseq-pages (f-expand (f-join org-roam-logseq/logseq-folder "pages")) "Logseq pages directory." :type 'directory :group 'org-roam-logseq)
 
 
 ;; default: exclude all files in the logseq/bak/ folder
-(defcustom org-roam-logseq/logseq-exclude-pattern (string-join (list "^" (file-truename org-roam-logseq/logseq-folder) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
-(defcustom org-roam-logseq/ignore-journal-files t "When non-nil, journal files will be ignored")
+(defcustom org-roam-logseq/logseq-exclude-pattern
+  (string-join (list "^" (file-truename org-roam-logseq/logseq-folder) "/logseq/bak/.*$"))
+  "Patterns of files that aren't supposed to be part of logseq."
+  :type 'regex
+  :group 'org-roam-logseq)
+
+(defcustom org-roam-logseq/ignore-journal-files t "When non-nil, journal files will be ignored." :type 'boolean :group 'org-roam-logseq)
 
 
-(defcustom org-roam-logseq/logseq-id-title-mod-path org-roam-logseq/logseq-pages "paths where id and title additions are allowed")
+(defcustom org-roam-logseq/logseq-id-title-mod-path org-roam-logseq/logseq-pages "Paths where id and title additions are allowed." :type 'directory :group 'org-roam-logseq)
 
-(defcustom org-roam-logseq/ignore-file-links t "When non-nil, file-links will not be converted, only fuzzy links")
+(defcustom org-roam-logseq/ignore-file-links t "When non-nil, file-links will not be converted, only fuzzy links." :type 'boolean :group 'org-roam-logseq)
 
 (defun org-roam-logseq/logseq-journal-p (file) (string-match-p (concat "^" org-roam-logseq/logseq-journals) file))
 
 (defun org-roam-logseq-ensure-file-id (file)
-  "Visit an existing file, ensure it has an id, return whether the a new buffer was created"
+  "Visit an existing file, ensure it has an id, return whether the a new buffer was created."
   (setq file (f-expand file))
   ;; do nothing at all when file is excluded by exclude pattern
   (if (string-match-p org-roam-logseq/logseq-exclude-pattern (file-truename file))

--- a/org-roam-logseq.el
+++ b/org-roam-logseq.el
@@ -42,20 +42,20 @@
 (require 'org-roam)
 
 ;; You probably don't need to change these values
-(defcustom bill/logseq-journals (f-expand (f-join org-roam-directory "journals")) "logseq journal directory")
+(defcustom org-roam-logseq-logseq-journals (f-expand (f-join org-roam-directory "journals")) "logseq journal directory")
 ;; ignore files matching bill/logseq-exclude-pattern
 ;; default: exclude all files in the logseq/bak/ folder
-(defcustom bill/logseq-exclude-pattern (string-join (list "^" (file-truename org-roam-directory) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
+(defcustom org-roam-logseq-logseq-exclude-pattern (string-join (list "^" (file-truename org-roam-directory) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
 (defcustom org-roam-logseq/ignore-journal-files t "When non-nil, journal files will be ignored")
 
 (defcustom org-roam-logseq/ignore-file-links t "When non-nil, file-links will not be converted, only fuzzy links")
 
-(defun bill/logseq-journal-p (file) (string-match-p (concat "^" bill/logseq-journals) file))
+(defun org-roam-logseq-logseq-journal-p (file) (string-match-p (concat "^" org-roam-logseq-logseq-journals) file))
 
-(defun bill/ensure-file-id (file)
+(defun org-roam-logseq-ensure-file-id (file)
   "Visit an existing file, ensure it has an id, return whether the a new buffer was created"
   (setq file (f-expand file))
-  (if (and org-roam-logseq/ignore-journal-files (bill/logseq-journal-p file) )
+  (if (and org-roam-logseq/ignore-journal-files (org-roam-logseq-logseq-journal-p file) )
       ;; do nothing for journal files if org-roam-logseq/ignore-journal-files is non-nil
       ;; TODO double check this is actually desired behaviour
       `(nil . nil)
@@ -100,7 +100,7 @@
       (when changed (save-buffer))
       (cons new-buf buf))))
 
-(defun bill/convert-logseq-file (buf)
+(defun org-roam-logseq-convert-logseq-file (buf)
   "convert fuzzy and file:../pages logseq links in the file to id links"
   (save-excursion
     (let* (changed
@@ -109,7 +109,7 @@
       (goto-char 1)
       (while (search-forward "[[" nil t)
         (setq link (org-element-context))
-        (setq newlink (bill/reformat-link link))
+        (setq newlink (org-roam-logseq-reformat-link link))
         (when newlink
           (setq changed t)
           (goto-char (org-element-property :begin link))
@@ -120,7 +120,7 @@
       ;; ensure org-roam knows about the changed links
       (when changed (save-buffer)))))
 
-(defun bill/reformat-link (link)
+(defun org-roam-logseq-reformat-link (link)
   (let (filename
         title
         id
@@ -170,31 +170,31 @@
                              (org-element-property :end link))))
             newlink))))))
 
-(defun bill/roam-file-modified-p (file-path)
-  (and (not (string-match-p bill/logseq-exclude-pattern (file-truename file-path)))
+(defun org-roam-logseq-roam-file-modified-p (file-path)
+  (and (not (string-match-p org-roam-logseq-logseq-exclude-pattern (file-truename file-path)))
        (let ((content-hash (org-roam-db--file-hash file-path))
              (db-hash (caar (org-roam-db-query [:select hash :from files
                                                         :where (= file $s1)] file-path))))
          (not (string= content-hash db-hash)))))
 
-(defun bill/modified-logseq-files ()
+(defun org-roam-logseq-modified-logseq-files ()
   (emacsql-with-transaction (org-roam-db)
-    (seq-filter 'bill/roam-file-modified-p
+    (seq-filter 'org-roam-logseq-roam-file-modified-p
                 (org-roam--list-files org-roam-directory))))
 
-(defun bill/check-logseq ()
+(defun org-roam-logseq-check-logseq ()
   (interactive)
   (setq files (org-roam--list-files org-roam-directory))
-  (message "bill/check-logseq is processing %d" (length files))
+  (message "org-roam-logseq-check-logseq is processing %d" (length files))
   (org-roam-logseq-patch files)
   )
 
-(defun bill/check-logseq-unsynced ()
+(defun org-roam-logseq-check-logseq-unsynced ()
   (interactive)
   (setq files (org-roam--list-files org-roam-directory))
   (setq files-in-db (apply #'append (org-roam-db-query [:select file :from files])))
   (setq unsynced-files (cl-set-difference files files-in-db :test #'file-equal-p))
-  (message "bill/check-logseq-unsynced is processing %d" (length unsynced-files))
+  (message "org-roam-logseq-check-logseq-unsynced is processing %d" (length unsynced-files))
   (org-roam-logseq-patch unsynced-files)
   )
 
@@ -203,10 +203,10 @@
     ;; make sure all the files have file ids
     (dolist (file-path files)
       (setq file-path (f-expand file-path))
-      (setq cur (bill/ensure-file-id file-path))
+      (setq cur (org-roam-logseq-ensure-file-id file-path))
       (setq buf (cdr cur))
       (push buf bufs)
-      (when (and (or (not org-roam-logseq/ignore-journal-files) (not (bill/logseq-journal-p file-path)) )
+      (when (and (or (not org-roam-logseq/ignore-journal-files) (not (org-roam-logseq-logseq-journal-p file-path)) )
                  (not buf))
         (push file-path bad))
       (when (not (buffer-modified-p buf))
@@ -214,7 +214,7 @@
       (when (car cur)
         (push buf created)))
     ;; patch fuzzy links
-    (mapc 'bill/convert-logseq-file
+    (mapc 'org-roam-logseq-convert-logseq-file
           (seq-filter 'identity bufs))
     (dolist (buf unmodified)
       (when (buffer-modified-p buf)
@@ -228,8 +228,8 @@
   "Process any org-roam files on accessing if they have logseq links."
   (when (org-roam-file-p)
     (progn
-      (bill/ensure-file-id (buffer-file-name (current-buffer)))
-      (bill/convert-logseq-file (current-buffer)))))
+      (org-roam-logseq-ensure-file-id (buffer-file-name (current-buffer)))
+      (org-roam-logseq-convert-logseq-file (current-buffer)))))
 
 (add-hook 'find-file-hook #'org-roam-logseq-hook)
 

--- a/org-roam-logseq.el
+++ b/org-roam-logseq.el
@@ -43,13 +43,13 @@
 
 ;; You probably don't need to change these values
 (defcustom org-roam-logseq-logseq-journals (f-expand (f-join org-roam-directory "journals")) "logseq journal directory")
-;; ignore files matching bill/logseq-exclude-pattern
+
 ;; default: exclude all files in the logseq/bak/ folder
 (defcustom org-roam-logseq-logseq-exclude-pattern (string-join (list "^" (file-truename org-roam-directory) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
 (defcustom org-roam-logseq/ignore-journal-files t "When non-nil, journal files will be ignored")
 
 
-(defcustom org-roam-logseq/logseq-id-title-mod-path (f-expand (f-join bill/logseq-folder "pages")) "paths where id and title additions are allowed")
+(defcustom org-roam-logseq/logseq-id-title-mod-path (f-expand (f-join org-roam-directory "pages")) "paths where id and title additions are allowed")
 
 (defcustom org-roam-logseq/ignore-file-links t "When non-nil, file-links will not be converted, only fuzzy links")
 

--- a/org-roam-logseq.el
+++ b/org-roam-logseq.el
@@ -41,16 +41,11 @@
 (require 'cl-lib)
 (require 'org-roam)
 
-;; Your logseq directory should be inside your org-roam directory,
-;; put the directory you use here
-(defcustom bill/logseq-folder org-roam-directory "org-roam directory")
-
 ;; You probably don't need to change these values
-(defcustom bill/logseq-pages (f-expand (f-join bill/logseq-folder "pages")) "logseq pages directory")
-(defcustom bill/logseq-journals (f-expand (f-join bill/logseq-folder "journals")) "logseq journal directory")
+(defcustom bill/logseq-journals (f-expand (f-join org-roam-directory "journals")) "logseq journal directory")
 ;; ignore files matching bill/logseq-exclude-pattern
 ;; default: exclude all files in the logseq/bak/ folder
-(defcustom bill/logseq-exclude-pattern (string-join (list "^" (file-truename bill/logseq-folder) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
+(defcustom bill/logseq-exclude-pattern (string-join (list "^" (file-truename org-roam-directory) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
 (defcustom org-roam-logseq/ignore-journal-files t "When non-nil, journal files will be ignored")
 
 (defcustom org-roam-logseq/ignore-file-links t "When non-nil, file-links will not be converted, only fuzzy links")
@@ -185,18 +180,18 @@
 (defun bill/modified-logseq-files ()
   (emacsql-with-transaction (org-roam-db)
     (seq-filter 'bill/roam-file-modified-p
-                (org-roam--list-files bill/logseq-folder))))
+                (org-roam--list-files org-roam-directory))))
 
 (defun bill/check-logseq ()
   (interactive)
-  (setq files (org-roam--list-files bill/logseq-folder))
+  (setq files (org-roam--list-files org-roam-directory))
   (message "bill/check-logseq is processing %d" (length files))
   (org-roam-logseq-patch files)
   )
 
 (defun bill/check-logseq-unsynced ()
   (interactive)
-  (setq files (org-roam--list-files bill/logseq-folder))
+  (setq files (org-roam--list-files org-roam-directory))
   (setq files-in-db (apply #'append (org-roam-db-query [:select file :from files])))
   (setq unsynced-files (cl-set-difference files files-in-db :test #'file-equal-p))
   (message "bill/check-logseq-unsynced is processing %d" (length unsynced-files))

--- a/org-roam-logseq.el
+++ b/org-roam-logseq.el
@@ -52,6 +52,8 @@
 ;; default: exclude all files in the logseq/bak/ folder
 (defcustom bill/logseq-exclude-pattern (string-join (list "^" (file-truename bill/logseq-folder) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
 
+(defcustom org-roam-logseq/ignore-file-links t "When t, file-links will not be converted, only fuzzy links")
+
 (defun bill/logseq-journal-p (file) (string-match-p (concat "^" bill/logseq-journals) file))
 
 (defun bill/ensure-file-id (file)
@@ -146,7 +148,7 @@
                            (buffer-substring-no-properties contents-begin contents-end)
                            (org-element-property :raw-link link)
                          )))
-      (when (equal "file" (org-element-property :type link))
+      (when (and org-roam-logseq/ignore-file-links (equal "file" (org-element-property :type link)))
         ;; TODO create a workaround for Logseq's bug with aliases
         (setq filename (f-expand (replace-regexp-in-string "\\..//" "/" (org-element-property :path link))))
         (if (org-element-property :contents-begin link)

--- a/org-roam-logseq.el
+++ b/org-roam-logseq.el
@@ -51,16 +51,17 @@
 ;; ignore files matching bill/logseq-exclude-pattern
 ;; default: exclude all files in the logseq/bak/ folder
 (defcustom bill/logseq-exclude-pattern (string-join (list "^" (file-truename bill/logseq-folder) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
+(defcustom org-roam-logseq/ignore-journal-files t "When non-nil, journal files will be ignored")
 
-(defcustom org-roam-logseq/ignore-file-links t "When t, file-links will not be converted, only fuzzy links")
+(defcustom org-roam-logseq/ignore-file-links t "When non-nil, file-links will not be converted, only fuzzy links")
 
 (defun bill/logseq-journal-p (file) (string-match-p (concat "^" bill/logseq-journals) file))
 
 (defun bill/ensure-file-id (file)
   "Visit an existing file, ensure it has an id, return whether the a new buffer was created"
   (setq file (f-expand file))
-  (if (bill/logseq-journal-p file)
-      ;; do nothing for journal files
+  (if (and org-roam-logseq/ignore-journal-files (bill/logseq-journal-p file) )
+      ;; do nothing for journal files if org-roam-logseq/ignore-journal-files is non-nil
       ;; TODO double check this is actually desired behaviour
       `(nil . nil)
     (let* ((buf (get-file-buffer file))
@@ -210,7 +211,7 @@
       (setq cur (bill/ensure-file-id file-path))
       (setq buf (cdr cur))
       (push buf bufs)
-      (when (and (not (bill/logseq-journal-p file-path))
+      (when (and (or (not org-roam-logseq/ignore-journal-files) (not (bill/logseq-journal-p file-path)) )
                  (not buf))
         (push file-path bad))
       (when (not (buffer-modified-p buf))

--- a/org-roam-logseq.el
+++ b/org-roam-logseq.el
@@ -43,14 +43,14 @@
 
 ;; Your logseq directory should be inside your org-roam directory,
 ;; put the directory you use here
-(defvar bill/logseq-folder org-roam-directory)
+(defcustom bill/logseq-folder org-roam-directory "org-roam directory")
 
 ;; You probably don't need to change these values
-(defvar bill/logseq-pages (f-expand (f-join bill/logseq-folder "pages")))
-(defvar bill/logseq-journals (f-expand (f-join bill/logseq-folder "journals")))
+(defcustom bill/logseq-pages (f-expand (f-join bill/logseq-folder "pages")) "logseq pages directory")
+(defcustom bill/logseq-journals (f-expand (f-join bill/logseq-folder "journals")) "logseq journal directory")
 ;; ignore files matching bill/logseq-exclude-pattern
 ;; default: exclude all files in the logseq/bak/ folder
-(defvar bill/logseq-exclude-pattern (string-join (list "^" (file-truename bill/logseq-folder) "/logseq/bak/.*$")))
+(defcustom bill/logseq-exclude-pattern (string-join (list "^" (file-truename bill/logseq-folder) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
 
 (defun bill/logseq-journal-p (file) (string-match-p (concat "^" bill/logseq-journals) file))
 

--- a/org-roam-logseq.el
+++ b/org-roam-logseq.el
@@ -52,6 +52,9 @@
 ;; default: exclude all files in the logseq/bak/ folder
 (defcustom bill/logseq-exclude-pattern (string-join (list "^" (file-truename bill/logseq-folder) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
 
+
+(defcustom org-roam-logseq/logseq-id-title-mod-path (f-expand (f-join bill/logseq-folder "pages")) "paths where id and title additions are allowed")
+
 (defcustom org-roam-logseq/ignore-file-links t "When t, file-links will not be converted, only fuzzy links")
 
 (defun bill/logseq-journal-p (file) (string-match-p (concat "^" bill/logseq-journals) file))
@@ -59,7 +62,7 @@
 (defun bill/ensure-file-id (file)
   "Visit an existing file, ensure it has an id, return whether the a new buffer was created"
   (setq file (f-expand file))
-  (if (bill/logseq-journal-p file)
+  (if (and (bill/logseq-journal-p file) (not (string-match-p (concat "^" org-roam-logseq/logseq-id-title-mod-path) file)))
       ;; do nothing for journal files
       ;; TODO double check this is actually desired behaviour
       `(nil . nil)

--- a/org-roam-logseq.el
+++ b/org-roam-logseq.el
@@ -44,31 +44,31 @@
 ;; Your logseq directory should be inside your org-roam directory,
 ;; put the directory you use here
 ;; e.g. (defvar org-roam-logseq-folder (f-expand (f-join org-roam-directory "zettel")))
-(defcustom org-roam-logseq-logseq-folder (f-expand org-roam-directory) "root of the logseq directory")
+(defcustom org-roam-logseq/logseq-folder (f-expand org-roam-directory) "root of the logseq directory")
 
 ;; You probably don't need to change these values
-(defcustom org-roam-logseq-logseq-journals (f-expand (f-join org-roam-logseq-logseq-folder "journals")) "logseq journal directory")
-(defcustom org-roam-logseq-logseq-pages (f-expand (f-join org-roam-logseq-logseq-folder "pages")) "logseq pages directory")
+(defcustom org-roam-logseq/logseq-journals (f-expand (f-join org-roam-logseq/logseq-folder "journals")) "logseq journal directory")
+(defcustom org-roam-logseq/logseq-pages (f-expand (f-join org-roam-logseq/logseq-folder "pages")) "logseq pages directory")
 
 
 ;; default: exclude all files in the logseq/bak/ folder
-(defcustom org-roam-logseq-logseq-exclude-pattern (string-join (list "^" (file-truename org-roam-logseq-logseq-folder) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
+(defcustom org-roam-logseq/logseq-exclude-pattern (string-join (list "^" (file-truename org-roam-logseq/logseq-folder) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
 (defcustom org-roam-logseq/ignore-journal-files t "When non-nil, journal files will be ignored")
 
 
-(defcustom org-roam-logseq/logseq-id-title-mod-path org-roam-logseq-logseq-pages "paths where id and title additions are allowed")
+(defcustom org-roam-logseq/logseq-id-title-mod-path org-roam-logseq/logseq-pages "paths where id and title additions are allowed")
 
 (defcustom org-roam-logseq/ignore-file-links t "When non-nil, file-links will not be converted, only fuzzy links")
 
-(defun org-roam-logseq-logseq-journal-p (file) (string-match-p (concat "^" org-roam-logseq-logseq-journals) file))
+(defun org-roam-logseq/logseq-journal-p (file) (string-match-p (concat "^" org-roam-logseq/logseq-journals) file))
 
 (defun org-roam-logseq-ensure-file-id (file)
   "Visit an existing file, ensure it has an id, return whether the a new buffer was created"
   (setq file (f-expand file))
   ;; do nothing at all when file is excluded by exclude pattern
-  (if (string-match-p org-roam-logseq-logseq-exclude-pattern (file-truename file))
+  (if (string-match-p org-roam-logseq/logseq-exclude-pattern (file-truename file))
       (cons nil nil)
-    (if (or (and org-roam-logseq/ignore-journal-files (org-roam-logseq-logseq-journal-p file) ) (not (string-match-p (concat "^" org-roam-logseq/logseq-id-title-mod-path) file)))
+    (if (or (and org-roam-logseq/ignore-journal-files (org-roam-logseq/logseq-journal-p file) ) (not (string-match-p (concat "^" org-roam-logseq/logseq-id-title-mod-path) file)))
         ;; do not add id and title for journal files if org-roam-logseq/ignore-journal-files is non-nil. Also if file doesn't match org-roam-logseq/logseq-id-title-mod-path
         (if-let ( (buf (get-file-buffer file)) )
             (cons nil buf)
@@ -117,7 +117,7 @@
 
 (defun org-roam-logseq-convert-logseq-file (buf)
   "convert fuzzy and file:../pages logseq links in the file to id links"
-  (if (string-match-p org-roam-logseq-logseq-exclude-pattern (file-truename (buffer-file-name buf)))
+  (if (string-match-p org-roam-logseq/logseq-exclude-pattern (file-truename (buffer-file-name buf)))
       ;; do nothing at all if file is in exclude pattern
       nil
     (save-excursion
@@ -189,7 +189,7 @@
             newlink))))))
 
 (defun org-roam-logseq-roam-file-modified-p (file-path)
-  (and (not (string-match-p org-roam-logseq-logseq-exclude-pattern (file-truename file-path)))
+  (and (not (string-match-p org-roam-logseq/logseq-exclude-pattern (file-truename file-path)))
        (let ((content-hash (org-roam-db--file-hash file-path))
              (db-hash (caar (org-roam-db-query [:select hash :from files
                                                 :where (= file $s1)] file-path))))
@@ -198,18 +198,18 @@
 (defun org-roam-logseq-modified-logseq-files ()
   (emacsql-with-transaction (org-roam-db)
     (seq-filter 'org-roam-logseq-roam-file-modified-p
-                (org-roam--list-files org-roam-logseq-logseq-folder))))
+                (org-roam--list-files org-roam-logseq/logseq-folder))))
 
 (defun org-roam-logseq-check-logseq ()
   (interactive)
-  (setq files (org-roam--list-files org-roam-logseq-logseq-folder))
+  (setq files (org-roam--list-files org-roam-logseq/logseq-folder))
   (message "org-roam-logseq-check-logseq is processing %d" (length files))
   (org-roam-logseq-patch files)
   )
 
 (defun org-roam-logseq-check-logseq-unsynced ()
   (interactive)
-  (setq files (org-roam--list-files org-roam-logseq-logseq-folder))
+  (setq files (org-roam--list-files org-roam-logseq/logseq-folder))
   (setq files-in-db (apply #'append (org-roam-db-query [:select file :from files])))
   (setq unsynced-files (cl-set-difference files files-in-db :test #'file-equal-p))
   (message "org-roam-logseq-check-logseq-unsynced is processing %d" (length unsynced-files))
@@ -224,7 +224,7 @@
       (setq cur (org-roam-logseq-ensure-file-id file-path))
       (setq buf (cdr cur))
       (push buf bufs)
-      (when (and (or (not org-roam-logseq/ignore-journal-files) (not (org-roam-logseq-logseq-journal-p file-path)) )
+      (when (and (or (not org-roam-logseq/ignore-journal-files) (not (org-roam-logseq/logseq-journal-p file-path)) )
                  (not buf))
         (push file-path bad))
       (when (not (buffer-modified-p buf))

--- a/org-roam-logseq.el
+++ b/org-roam-logseq.el
@@ -80,7 +80,7 @@
   ;; do nothing at all when file is excluded by exclude pattern
   (if (string-match-p org-roam-logseq/logseq-exclude-pattern (file-truename file))
       (cons nil nil)
-    (if (or (and org-roam-logseq/ignore-journal-files (org-roam-logseq/logseq-journal-p file) ) (not (string-match-p (concat "^" org-roam-logseq/logseq-id-title-mod-path) file)))
+    (if (and (and org-roam-logseq/ignore-journal-files (org-roam-logseq/logseq-journal-p file) ) (not (string-match-p (concat "^" org-roam-logseq/logseq-id-title-mod-path) file)))
         ;; do not add id and title for journal files if org-roam-logseq/ignore-journal-files is non-nil. Also if file doesn't match org-roam-logseq/logseq-id-title-mod-path
         (if-let ( (buf (get-file-buffer file)) )
             (cons nil buf)

--- a/org-roam-logseq.el
+++ b/org-roam-logseq.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 2023, Ivan Danov
 
 ;; Author: Ivan Danov
+;; Modified By: Frederick Morlock, ps251 (GitHub)
 ;; URL: https://github.com/idanov/org-roam-logseq.el/
 ;; Keywords: org-mode, roam, logseq
 ;; Version: 0.1.0

--- a/org-roam-logseq.el
+++ b/org-roam-logseq.el
@@ -48,13 +48,15 @@
 
 ;; You probably don't need to change these values
 (defcustom org-roam-logseq-logseq-journals (f-expand (f-join org-roam-logseq-logseq-folder "journals")) "logseq journal directory")
+(defcustom org-roam-logseq-logseq-pages (f-expand (f-join org-roam-logseq-logseq-folder "pages")) "logseq pages directory")
+
 
 ;; default: exclude all files in the logseq/bak/ folder
 (defcustom org-roam-logseq-logseq-exclude-pattern (string-join (list "^" (file-truename org-roam-logseq-logseq-folder) "/logseq/bak/.*$")) "patterns of files that aren't supposed to be part of logseq")
 (defcustom org-roam-logseq/ignore-journal-files t "When non-nil, journal files will be ignored")
 
 
-(defcustom org-roam-logseq/logseq-id-title-mod-path (f-expand (f-join org-roam-logseq-logseq-folder "pages/")) "paths where id and title additions are allowed")
+(defcustom org-roam-logseq/logseq-id-title-mod-path org-roam-logseq-logseq-pages "paths where id and title additions are allowed")
 
 (defcustom org-roam-logseq/ignore-file-links t "When non-nil, file-links will not be converted, only fuzzy links")
 


### PR DESCRIPTION
## Changelog
(as far as I know)
- Change package namespace from `bill/` to `org-roam-logseq`
- Add option for adding dates to journal files
- Convert `defvar` -> `defcustom`

## TODO

- [x] Reintroduce `logseq-folder` variable. It's unneeded, but can be useful. It's more flexible!
     - Note that `logseq-folder` becomes "useless" because of a divergence from the upstream repo from [the original `.el` file gist](https://gist.github.com/zot/ddf1a89a567fea73bc3c8a209d48f527).
- [x] Reintroduce missing `logseq-pages` variable.
    - It seems to get merged into `logseq-id-title-mod-path` variable.
- [x] Add proper `defcustom` support.
- [x] Use journal settings are respected.